### PR TITLE
Fix pytest no terminal issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Text User Interface for running python tests. Still in _beta_ version
   - <kbd>alt</kbd> + <kbd>up</kbd>/<kbd>down</kbd> - navigate between failed tests (skipping passed)
   - <kbd>q</kbd> - close window, quit (in main window)
 
+## filter input
+By default, filter input is in fuzzy mode. This could be avoided by using dash signs,
+where exact match mode is used between a pair of them. For example
+
+abc#match#def will match fuzzy "abc", then exactly "match" and then again fuzzy "def"
+
 # main goals
 The goal of this project is to ease the testing process by
   - [x] selecting tests to run using fuzzy filter

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Text User Interface for running python tests. Still in _beta_ version
 
 # controls
   - <kbd>r</kbd>, <kbd>F5</kbd> - run tests (last failed or first run, using filter)
-  - <kbd>R</kbd>, <kbd>ctrl</kbd> + <kbd>f5</kbd> - run all tests (using filter)
+  - <kbd>R</kbd>, <kbd>ctrl</kbd> + <kbd>F5</kbd> - run all tests (using filter)
   - <kbd>/</kbd> - focus filter input
   - <kbd>ctrl</kbd> + <kbd>f</kbd> - clear filter input and focus it
   - <kbd>F4</kbd> - toggle show only failed tests
@@ -23,7 +23,7 @@ Text User Interface for running python tests. Still in _beta_ version
 By default, filter input is in fuzzy mode. This could be avoided by using dash signs,
 where exact match mode is used between a pair of them. For example
 
-abc#match#def will match fuzzy "abc", then exactly "match" and then again fuzzy "def"
+`abc#match#def` will match fuzzy "abc", then exactly "match" and then again fuzzy "def"
 
 # main goals
 The goal of this project is to ease the testing process by

--- a/draft/test_importerror.py
+++ b/draft/test_importerror.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from builtins import object
 import sys
 import pytest
 import unittest
@@ -10,10 +12,10 @@ logger = logging.getLogger(__name__)
 
 class PutrPytestPlugin(object):
     def pytest_runtest_protocol(self, item, nextitem):
-        print 'pytest_runtest_protocol %s %s' % (item, nextitem)
+        print('pytest_runtest_protocol %s %s' % (item, nextitem))
 
     def pytest_runtest_makereport(self, item, call):
-        print 'pytest_runtest_makereport %s %s' % (item, call)
+        print('pytest_runtest_makereport %s %s' % (item, call))
 
     # @pytest.hookimpl(hookwrapper=True)
     # def pytest_runtest_makereport(self, item, call):
@@ -31,16 +33,16 @@ class PutrPytestPlugin(object):
     #     logger.debug('pytest_runtest_makereport %s %s', item, call)
 
     def pytest_itemcollected(self, item):
-        print 'pytest_itemcollected %s' % item
+        print('pytest_itemcollected %s' % item)
 
     def pytest_collectstart(self, collector):
-        print 'pytest_collectstart(self, collector)'
+        print('pytest_collectstart(self, collector)')
 
     def pytest_collectreport(self, report):
         pass
 
     def pytest_runtest_logreport(self, report):
-        print 'pytest_runtest_logreport'
+        print('pytest_runtest_logreport')
         logger.debug('report %s', report)
         logger.debug('report.capstdout %s', report.capstdout)
         logger.debug('report.capstderr %s', report.capstderr)
@@ -49,5 +51,5 @@ class PutrPytestPlugin(object):
 if __name__ == '__main__':
     logging_tools.configure()
 
-    print sys.path
+    print(sys.path)
     pytest.main(['-p', 'no:terminal', 'test_projects/test_module_a/test_feat_1.py'], plugins=[PutrPytestPlugin()])

--- a/draft/test_overlay.py
+++ b/draft/test_overlay.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
+from __future__ import print_function
 import urwid
+import sys
 
 class TestResultWindow(urwid.WidgetWrap):
     _sizing = frozenset(['box'])
@@ -27,7 +29,7 @@ class TestResultWindow2(urwid.LineBox):
         super(TestResultWindow2, self).__init__(urwid.Filler(urwid.Text(text)))
 
     def keypress(self, size, key):
-        print 'here'
+        print('here')
         raise urwid.ExitMainLoop()
         if key == 'esc':
             self.escape_method()
@@ -50,15 +52,13 @@ w_main = urwid.Overlay(
 
 def handle_input(key):
     if key in ('q', 'Q'):
-        print 'exiting on q'
+        print('exiting on q')
         raise urwid.ExitMainLoop()
     elif key in ('1'):
         main_loop.widget = urwid.LineBox(urwid.Filler(urwid.Text('The second top window', align='right')))
-        
 
-if __name__ != '__main__':
-    sys.exit(1)
 
-main_loop = urwid.MainLoop(w_main, palette=[('reversed', 'standout', '')],
-               unhandled_input=handle_input)
-main_loop.run()
+if __name__ == '__main__':
+    main_loop = urwid.MainLoop(w_main, palette=[('reversed', 'standout', '')],
+                   unhandled_input=handle_input)
+    main_loop.run()

--- a/draft/test_stdout_capture.py
+++ b/draft/test_stdout_capture.py
@@ -1,9 +1,12 @@
+from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
 #!/usr/bin/env python
 # encoding: utf-8
 
 import sys
 import unittest
-from StringIO import StringIO
+from io import StringIO
 
 
 if __name__ == '__main__':
@@ -25,7 +28,7 @@ if __name__ == '__main__':
 	sys.stdout = _orig_stdout
 	sys.stderr = _orig_stderr
 
-	print 'And here is the output'
-	print test_output
-	print 'And here is the error output'
-	print test_output_err
+	print('And here is the output')
+	print(test_output)
+	print('And here is the error output')
+	print(test_output_err)

--- a/pytui/common.py
+++ b/pytui/common.py
@@ -1,15 +1,30 @@
 from __future__ import unicode_literals
+from builtins import object
 
 import re
 
+def get_fuzzy_regex(fuzzy_str):
+    return '.*?'.join(list(iter(
+        fuzzy_str.replace('.', r'\.').replace(r'\\', '\\\\')
+    )))
+
+
+def get_filter_regex_str(filter_value):
+    filter_exact = ''
+
+    pieces = filter_value.split('#')
+
+    return ''.join(
+        (   get_fuzzy_regex(value) if i % 2 == 0 else value
+            for i, value in enumerate(pieces)
+        )
+    )
 
 def get_filter_regex(filter_value):
     if not filter_value:
         return None
 
-    regexp_str = '.*?'.join(list(iter(
-        filter_value.replace('.', '\.').replace(r'\\', '\\\\')
-    )))
+    regexp_str = get_filter_regex_str(filter_value)
     return re.compile(regexp_str, re.UNICODE + re.IGNORECASE)
 
 

--- a/pytui/logging_tools.py
+++ b/pytui/logging_tools.py
@@ -4,6 +4,7 @@ from builtins import object
 
 import logging
 import logging.config
+from io import IOBase
 
 from . import settings
 
@@ -20,15 +21,14 @@ def get_logger(name, *args):
     return logging.getLogger('.'.join(['pytui', name] + list(args)))
 
 
-class LogWriter(object):
+class LogWriter(IOBase):
     def __init__(self, logger):
         self.logger = logger
+        self._data = []
 
     def write(self, message):
-        self.logger.debug('STDOUT: (%s)\n', message.strip('\n'))
-
-    def flush(self):
-        pass
+        # self.logger.debug('STDOUT: (%s)\n', message.strip('\n'))
+        self._data.append(message)
 
 
 def configure(filename, debug):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from unittest import TestCase
+from pytui.common import get_filter_regex_str
+
+
+def test_filter_regex_str():
+    regex = get_filter_regex_str('abc#efg')
+    assert regex == 'a.*?b.*?cefg'

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from __future__ import absolute_import
 
 try:
     from unittest import mock
@@ -32,10 +33,13 @@ class PytestRunnerTests(TestCase):
         )
         with mock.patch.object(PytestRunner, 'pipe_send') as pipe_send_mock:
             logger.debug('------ runner init ------')
-            runner.init_tests()
+            exitcode, _description = runner.init_tests()
+            assert exitcode == 0
             # logger.debug(pipe_send_mock.call_args_list)
+
             logger.debug('------ runner run_tests ------')
-            runner.run_tests(False, 'xfail')
+            exitcode, _description = runner.run_tests(False, 'xfail')
+            assert exitcode == 1
             logger.debug(pipe_send_mock.call_args_list)
 
     @mock.patch.object(PytestRunner, 'init_tests', return_value=(1, None))


### PR DESCRIPTION
- do not disable the `terminal` plugin to suppress output, it breaks other plugins
- make tests python 3 compatible
- add exact search using #